### PR TITLE
Fix base path configuration for GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL}>
           <ScrollToTop />
           <Routes>
             <Route path="/" element={<Index />} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: "/cohereboulder.org/",
+  base: mode === "production" ? "/cohereboulder.org/" : "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
- Make base path conditional (only apply in production)
- Configure React Router to use BASE_URL from Vite
- Fixes 404 errors on GitHub Pages
- Fixes broken URLs in local development