### PR TITLE
Fix: Add Google Maps API key to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
         run: npm run build
 
       - name: Setup Pages


### PR DESCRIPTION
## Overview
Fixes the Google Maps location autocomplete not working in production.

## Problem
- Google Maps API key was added to GitHub Secrets
- But the deployment workflow wasn't configured to use it
- This caused the location autocomplete to show "API key not found" error

## Solution
- Added `VITE_GOOGLE_MAPS_API_KEY` to the build environment variables in GitHub Actions workflow
- Now the API key from GitHub Secrets will be included during the build process

## Testing
After merging and deployment:
1. Go to the Events Management page
2. Try adding a new event
3. The location field should now have working autocomplete

## Prerequisites
Make sure `VITE_GOOGLE_MAPS_API_KEY` is set in your GitHub repository secrets:
1. Go to Settings → Secrets and variables → Actions
2. Verify `VITE_GOOGLE_MAPS_API_KEY` exists with your new API key

This should fix the location autocomplete in production.